### PR TITLE
Use `--namespace default` explicitly

### DIFF
--- a/target-scripts/setup-container.sh
+++ b/target-scripts/setup-container.sh
@@ -5,7 +5,7 @@
 
 # Load images
 echo "==> Load registry, nginx images"
-NERDCTL=/usr/local/bin/nerdctl
+NERDCTL="/usr/local/bin/nerdctl --namespace default"
 cd ./images
 
 for f in docker.io_library_registry-*.tar.gz docker.io_library_nginx-*.tar.gz; do

--- a/target-scripts/start-nginx.sh
+++ b/target-scripts/start-nginx.sh
@@ -7,7 +7,7 @@ if [ ! -d images ] && [ -d ../outputs ]; then
     BASEDIR="../outputs"  # for tests
 fi
 BASEDIR=$(cd $BASEDIR; pwd)
-NERDCTL="sudo /usr/local/bin/nerdctl"
+NERDCTL="sudo /usr/local/bin/nerdctl --namespace default"
 
 NGINX_IMAGE=nginx:${NGINX_VERSION}
 

--- a/target-scripts/start-registry.sh
+++ b/target-scripts/start-registry.sh
@@ -4,13 +4,19 @@ source ./config.sh
 
 REGISTRY_IMAGE=registry:${REGISTRY_VERSION}
 REGISTRY_DIR=${REGISTRY_DIR:-/var/lib/registry}
+NERDCTL="sudo /usr/local/bin/nerdctl --namespace default"
 
 if [ ! -e $REGISTRY_DIR ]; then
     sudo mkdir $REGISTRY_DIR
 fi
 
+echo "===> Stop registry"
+$NERDCTL container update --restart no registry 2>/dev/null
+$NERDCTL container stop registry 2>/dev/null
+$NERDCTL container rm registry 2>/dev/null
+
 echo "===> Start registry"
-sudo /usr/local/bin/nerdctl run -d \
+$NERDCTL run -d \
     --network host \
     -e REGISTRY_HTTP_ADDR=0.0.0.0:${REGISTRY_PORT} \
     --restart always \


### PR DESCRIPTION
At first, `nerdctl` uses `"default"` as the default namespace.
But `nerdctl` uses `k8s.io` as default namespace after deploying a cluster.
So `NERDCTL` should use `"default"` namespace explicitly.

I think `start-registry.sh` is better if  it is idempotent same as `start-nginx.sh`.